### PR TITLE
Implement edge-to-edge UI in settings

### DIFF
--- a/app/src/main/java/com/github/pixelupdater/pixelupdater/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/pixelupdater/pixelupdater/settings/SettingsActivity.kt
@@ -8,13 +8,23 @@
 package com.github.pixelupdater.pixelupdater.settings
 
 import android.os.Bundle
+import android.view.ViewGroup
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import com.github.pixelupdater.pixelupdater.R
+import com.github.pixelupdater.pixelupdater.databinding.SettingsActivityBinding
 
 class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.settings_activity)
+
+        val binding = SettingsActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
         if (savedInstanceState == null) {
             supportFragmentManager
                     .beginTransaction()
@@ -22,6 +32,21 @@ class SettingsActivity : AppCompatActivity() {
                     .commit()
         }
 
-        setSupportActionBar(findViewById(R.id.toolbar))
+        ViewCompat.setOnApplyWindowInsetsListener(binding.toolbar) { v, windowInsets ->
+            val insets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+                        or WindowInsetsCompat.Type.displayCutout()
+            )
+
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                leftMargin = insets.left
+                topMargin = insets.top
+                rightMargin = insets.right
+            }
+
+            WindowInsetsCompat.CONSUMED
+        }
+
+        setSupportActionBar(binding.toolbar)
     }
 }

--- a/app/src/main/java/com/github/pixelupdater/pixelupdater/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/github/pixelupdater/pixelupdater/settings/SettingsFragment.kt
@@ -15,6 +15,8 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.provider.DocumentsContract
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import android.provider.Settings
 import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
@@ -22,6 +24,9 @@ import android.util.Log
 import android.view.View
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
@@ -36,6 +41,7 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
 import androidx.preference.get
 import androidx.preference.size
+import androidx.recyclerview.widget.RecyclerView
 import com.github.pixelupdater.pixelupdater.BuildConfig
 import com.github.pixelupdater.pixelupdater.Notifications
 import com.github.pixelupdater.pixelupdater.Permissions
@@ -120,6 +126,37 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
         uri?.let {
             createSupportFile(it)
         }
+    }
+
+    override fun onCreateRecyclerView(
+        inflater: LayoutInflater,
+        parent: ViewGroup,
+        savedInstanceState: Bundle?
+    ): RecyclerView {
+        val view = super.onCreateRecyclerView(inflater, parent, savedInstanceState)
+
+        view.clipToPadding = false
+
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
+            val insets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+                        or WindowInsetsCompat.Type.displayCutout()
+            )
+
+            // This is a little bit ugly in landscape mode because the divider lines for categories
+            // extend into the inset area. However, it's worth applying the left/right padding here
+            // anyway because it allows the inset area to be used for scrolling instead of just
+            // being a useless dead zone.
+            v.updatePadding(
+                bottom = insets.bottom,
+                left = insets.left,
+                right = insets.right,
+            )
+
+            WindowInsetsCompat.CONSUMED
+        }
+
+        return view
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -1,20 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar"
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize" />
+        android:layout_height="wrap_content"
+        app:liftOnScroll="true">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
         android:id="@+id/settings"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-</LinearLayout>
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,9 +6,7 @@
 -->
 <resources>
     <style name="Theme.PixelUpdater" parent="Theme.Material3.DayNight.NoActionBar">
-        <item name="android:navigationBarColor">@android:color/transparent</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
-        <item name="windowActionModeOverlay">true</item>
+        <item name="switchPreferenceCompatStyle">@style/App.Widget.Material3.SwitchPreferenceCompat</item>
     </style>
+    <style name="App.Widget.Material3.SwitchPreferenceCompat" parent="Preference.SwitchPreferenceCompat.Material" />
 </resources>


### PR DESCRIPTION
- Enable edge-to-edge display for the settings activity.
- Apply window insets to the toolbar and `RecyclerView` to prevent content from being obscured by system bars or display cutouts.
- Update `settings_activity.xml` to use `CoordinatorLayout` and `AppBarLayout` for proper scrolling behavior with an edge-to-edge layout.
- Remove transparent navigation and status bar styles from the theme as they are now handled by the edge-to-edge implementation.

Credits / Upstream Reference
Logic ported/adapted from upstream commit: 
[2d792e0a1f35fdfc2863965bbea085c9f6804868](https://github.com/chenxiaolong/Custota/commit/2d792e0a1f35fdfc2863965bbea085c9f6804868)