### PR TITLE
Improve build filtering and add carrier build support

### DIFF
--- a/app/src/main/java/com/github/pixelupdater/pixelupdater/Preferences.kt
+++ b/app/src/main/java/com/github/pixelupdater/pixelupdater/Preferences.kt
@@ -39,6 +39,7 @@ class Preferences(context: Context) {
         const val PREF_OPEN_LOG_DIR = "open_log_dir"
         const val PREF_OTA_URL = "ota_url"
         const val PREF_ALLOW_REINSTALL = "allow_reinstall"
+        const val PREF_SHOW_CARRIER_BUILDS = "show_carrier_builds"
         const val PREF_REVERT_COMPLETED = "revert_completed"
         const val PREF_VERITY_ONLY = "verity_only"
         const val PREF_CREATE_SUPPORT_FILE = "create_support_file"
@@ -140,6 +141,11 @@ class Preferences(context: Context) {
     var allowReinstall: Boolean
         get() = prefs.getBoolean(PREF_ALLOW_REINSTALL, false)
         set(enabled) = prefs.edit { putBoolean(PREF_ALLOW_REINSTALL, enabled) }
+
+    /** Whether to show carrier builds. */
+    var showCarrierBuilds: Boolean
+        get() = prefs.getBoolean(PREF_SHOW_CARRIER_BUILDS, false)
+        set(enabled) = prefs.edit { putBoolean(PREF_SHOW_CARRIER_BUILDS, enabled) }
 
     /** URL of OTA update. */
     var otaUrl: URL?

--- a/app/src/main/java/com/github/pixelupdater/pixelupdater/updater/UpdaterThread.kt
+++ b/app/src/main/java/com/github/pixelupdater/pixelupdater/updater/UpdaterThread.kt
@@ -377,20 +377,39 @@ class UpdaterThread(
                 val columns = row.select("td")
                 val version = columns[0].text().trim()
                 val downloadUrl = columns[1].select("a").attr("href")
-                val dateMatch = Pattern.compile("\\b(\\d{6})\\b").matcher(version)
-                dateMatch.find()
+
+                val parenContent = version.substringAfter("(").substringBefore(")")
+                val parts = parenContent.split(",").map { it.trim() }
+
+                val fullBuildId = parts[0]
+                val isCarrierBuild = parts.size > 2
+
+                val dateMatch = Pattern.compile("\\b(\\d{6})\\b").matcher(fullBuildId)
+                if (!dateMatch.find()) continue
                 val date: String = dateMatch.group(1)!!
 
-                if (!prefs.allowReinstall && date.toInt() <= buildDate.toInt()) {
-                    continue
-                } else if (date.toInt() < buildDate.toInt()) {
+                if (isCarrierBuild && !prefs.showCarrierBuilds) {
                     continue
                 }
 
-                result.add(DownloadInfo(version, URL(downloadUrl), date))
+                val isNewerDate = date.toInt() > buildDate.toInt()
+                val isSameMonthDifferentBuild = (date == buildDate && fullBuildId != Build.ID)
+                val isExactSameBuild = (fullBuildId == Build.ID)
+
+                val shouldAdd = when {
+                    isNewerDate -> true
+                    isSameMonthDifferentBuild -> true
+                    isExactSameBuild && prefs.allowReinstall -> true
+                    // If date is same but it's the exact same ID, only allow if reinstall is on
+                    date == buildDate -> prefs.allowReinstall
+                    else -> false
+                }
+
+                if (shouldAdd) {
+                    result.add(DownloadInfo(version, URL(downloadUrl), date))
+                }
             }
         }
-
         return result
     }
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -75,6 +75,8 @@
     <string name="notification_preparing_install">Подготовка к установке обновления...</string>
     <string name="pref_allow_reinstall_desc">Если последняя OTA совпадает с текущим отпечатком ОС, воспринимать ее как обновление. Это может привести к постоянным переустановкам, если включены автоматические обновления.</string>
     <string name="pref_allow_reinstall_name">Разрешить переустановку</string>
+    <string name="pref_show_carrier_builds_name">Показывать операторские сборки</string>
+    <string name="pref_show_carrier_builds_desc">Показывать сборки для устройств операторов связи.</string>
     <string name="pref_android_version_name">Версия Android</string>
     <string name="pref_automatic_check_desc">Автоматически проверять наличие новых обновлений в фоновом режиме.</string>
     <string name="pref_automatic_check_name">Автоматически проверять наличие обновлений</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -84,6 +84,8 @@
     <string name="pref_open_log_dir_desc">Відкрити директорію з логами в системному файловому менеджері (DocumentsUI).</string>
     <string name="pref_allow_reinstall_name">Дозволити перевстановлення</string>
     <string name="pref_allow_reinstall_desc">Якщо остання OTA має такий же fingerprint як в поточній ОС, вважати її оновленням. Це може призвести до постійних перевстановлень, якщо ввімкнено автоматичні оновлення.</string>
+    <string name="pref_show_carrier_builds_name">Показувати операторські збірки</string>
+    <string name="pref_show_carrier_builds_desc">Показувати збірки для пристроїв операторів зв’язку.</string>
     <string name="pref_revert_completed_name">Відкликати завершене оновлення</string>
     <string name="pref_revert_completed_desc">Це можливо тільки після завершення оновлення, але до перезавантаження. Це запобігає перемиканню слота пристрою при наступному перезавантаженні. Це не скасовує операції, виконані на неактивному слоті.</string>
     <string name="pref_verity_only_name">Вимкнути лише verity</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -74,6 +74,8 @@
     <string name="pref_open_log_dir_desc">在系统文件管理器中打开日志目录。</string>
     <string name="pref_allow_reinstall_name">允许重新安装</string>
     <string name="pref_allow_reinstall_desc">当最新 OTA 匹配当前系统构建指纹时，将其视为更新。若启用自动更新，可能导致连续重装。</string>
+    <string name="pref_show_carrier_builds_name">显示运营商版本</string>
+    <string name="pref_show_carrier_builds_desc">显示来自运营商设备的版本。</string>
     <string name="pref_revert_completed_name">还原已完成的更新</string>
     <string name="pref_revert_completed_desc">仅在更新完成后但重启前可用。阻止设备下次重启时切换启动槽，但不会撤销在非活动槽上执行的操作。</string>
     <string name="pref_ota_url_name">OTA URL</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,8 @@
     <string name="pref_open_log_dir_desc">Open the log directory in the system file manager (DocumentsUI).</string>
     <string name="pref_allow_reinstall_name">Allow reinstall</string>
     <string name="pref_allow_reinstall_desc">If the latest OTA matches the current OS fingerprint, treat it as an update. This may cause continuous reinstalls if automatic updates are enabled.</string>
+    <string name="pref_show_carrier_builds_name">Show carrier builds</string>
+    <string name="pref_show_carrier_builds_desc">Show builds from carrier devices.</string>
     <string name="pref_revert_completed_name">Revert completed update</string>
     <string name="pref_revert_completed_desc">This is only possible after an update completes, but before rebooting. This prevents the device from switching slot on the next reboot. This does not undo the operations performed on the inactive slot.</string>
     <string name="pref_verity_only_name">Disable verity only</string>

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -153,6 +153,13 @@
             app:summary="@string/pref_allow_reinstall_desc"
             app:iconSpaceReserved="false" />
 
+        <SwitchPreferenceCompat
+            app:key="show_carrier_builds"
+            app:defaultValue="false"
+            app:title="@string/pref_show_carrier_builds_name"
+            app:summary="@string/pref_show_carrier_builds_desc"
+            app:iconSpaceReserved="false" />
+
         <Preference
             app:key="revert_completed"
             app:persistent="false"


### PR DESCRIPTION
Previously, the update scraper relied solely on a 6-digit date comparison, causing it to miss mid-month patches that shared the same date code. It also lacked the ability to distinguish between Global and Carrier-specific builds.

This commit introduces full Build ID comparison and carrier filtering to resolve these detection issues.

Changes:
- Add a preference to show or hide carrier-specific builds.
- Refine OTA version parsing to extract the full Build ID and carrier info.
- Update detection logic to include builds with the same date but different IDs.
- Improve "Allow reinstall" logic to correctly handle exact Build ID matches.
- Add UI strings and settings for carrier build visibility.
- Add placeholder UI strings for ru, uk, and zh-rCN.

Fixes #41