### PR TITLE
[codex] Fix install network constraint precheck

### DIFF
--- a/app/src/main/java/com/github/pixelupdater/pixelupdater/updater/UpdaterJob.kt
+++ b/app/src/main/java/com/github/pixelupdater/pixelupdater/updater/UpdaterJob.kt
@@ -172,58 +172,6 @@ class UpdaterJob: JobService() {
                     }
                 }
 
-                // Check network constraint manually
-                val hasUnmeteredNetworkRequirement = hasUnmeteredNetworkRequirement(jobInfo)
-
-                if (!constraintsFailed && hasUnmeteredNetworkRequirement && action == UpdaterThread.Action.INSTALL) {
-                    // Use system service to check if we have unmetered network
-                    val connectivityIntent = context.registerReceiver(null,
-                        android.content.IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION))
-
-                    if (connectivityIntent == null) {
-                        constraintsFailed = true
-                        errorReason = "network_unavailable"
-                        Log.d(TAG, "Network constraint not met: no connectivity info available")
-                    } else {
-                        val noConnectivity = connectivityIntent.getBooleanExtra(
-                            android.net.ConnectivityManager.EXTRA_NO_CONNECTIVITY, false)
-
-                        if (noConnectivity) {
-                            constraintsFailed = true
-                            errorReason = "network_unavailable"
-                            Log.d(TAG, "Network constraint not met: no connectivity")
-                        } else {
-                            // Check if connection is metered
-                            val netInfo = connectivityIntent.getParcelableExtra<android.net.NetworkInfo>(
-                                android.net.ConnectivityManager.EXTRA_NETWORK_INFO)
-
-                            if (netInfo == null || !netInfo.isConnected) {
-                                constraintsFailed = true
-                                errorReason = "network_unavailable"
-                                Log.d(TAG, "Network constraint not met: no active network")
-                            } else {
-                                // On newer Android versions, we need to use a system service
-                                // to check if the network is metered
-                                try {
-                                    val service = context.getSystemService("connectivity")
-                                    val isMeteredMethod = service.javaClass.getMethod(
-                                        "isActiveNetworkMetered")
-                                    val isMetered = isMeteredMethod.invoke(service) as Boolean
-
-                                    if (isMetered) {
-                                        constraintsFailed = true
-                                        errorReason = "network_metered"
-                                        Log.d(TAG, "Network constraint not met: network is metered")
-                                    }
-                                } catch (e: Exception) {
-                                    Log.e(TAG, "Failed to check if network is metered", e)
-                                    // Fall back to assume network is unmetered to avoid blocking updates
-                                }
-                            }
-                        }
-                    }
-                }
-
                 if (constraintsFailed && action != null) {
                     // Show an immediate toast message to provide feedback to the user
                     val toastText = when (errorReason) {

--- a/app/src/main/java/com/github/pixelupdater/pixelupdater/updater/UpdaterService.kt
+++ b/app/src/main/java/com/github/pixelupdater/pixelupdater/updater/UpdaterService.kt
@@ -78,7 +78,8 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
 
                     val messageResId = when (failureReason) {
                         "battery_low" -> R.string.notification_job_failed_battery_message
-                        "network_metered", "network_unavailable" -> R.string.notification_job_failed_network_message
+                        "network_metered" -> R.string.notification_job_failed_network_message
+                        "network_unavailable" -> R.string.notification_update_network_unavailable_message
                         else -> {
                             if (extraAction == UpdaterThread.Action.INSTALL && prefs.requireUnmetered && prefs.requireBatteryNotLow) {
                                 R.string.notification_job_failed_both_message


### PR DESCRIPTION
## Summary

Remove the immediate install path's manual network constraint check that used the deprecated `CONNECTIVITY_ACTION` sticky broadcast and deprecated `NetworkInfo`. The install job still requests `JobInfo.NETWORK_TYPE_UNMETERED` when the user requires an unmetered connection, so JobScheduler remains responsible for selecting a matching network and passing it to `UpdaterJob.onStartJob()`.

Also distinguish `network_unavailable` from `network_metered` in the install failure notification so unavailable-network failures do not tell users to disable the unmetered-network requirement.

## Root Cause

The pre-scheduling check could see stale or missing legacy broadcast state even when JobScheduler and ConnectivityService considered the app's VPN-backed network valid and unmetered. In that case, the install path failed before JobScheduler could run the job on the network it had already selected.

## Validation

- `./gradlew testDebugUnitTest`
- Confirmed the PR branch is one commit ahead of `PixelUpdater/PixelUpdater:development` and touches only `UpdaterJob.kt` and `UpdaterService.kt`.